### PR TITLE
close the Channel on timeout

### DIFF
--- a/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
+++ b/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
@@ -300,7 +300,7 @@ final class JsonRpcTests: XCTestCase {
         _ = try! client.connect(host: address.0, port: address.1).wait()
         // perform the method call
         XCTAssertThrowsError(try client.call(method: "timeout", params: .none).wait()) { error in
-            XCTAssertEqual(error as! ClientError, ClientError.timeout)
+            XCTAssertEqual(error as! ClientError, ClientError.connectionResetByPeer)
         }
         // shutdown
         try! client.disconnect().wait()


### PR DESCRIPTION
this fixes this program by closing the `Channel` if we hit a timeout.

Why is this a better solution? The idea in the program is that if we didn't receive something after 100ms, then we emit a `.badFraming` error and give up. This is best achieved by just closing the `Channel` because we have given up by this point and nothing will be able to repair the channel anymore.