### PR TITLE
some cleanups

### DIFF
--- a/json-rpc/Package.swift
+++ b/json-rpc/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 var targets: [PackageDescription.Target] = [
-    .target(name: "JSONRPC", dependencies: ["NIO", "NIOFoundationCompat"]),
+    .target(name: "JSONRPC", dependencies: ["NIO", "NIOFoundationCompat", "NIOExtras"]),
     .target(name: "ServerExample", dependencies: ["JSONRPC"]),
     .target(name: "ClientExample", dependencies: ["JSONRPC"]),
     .target(name: "LightsdDemo", dependencies: ["JSONRPC"]),
@@ -21,6 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras", from: "1.0.0"),
     ],
     targets: targets
 )

--- a/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
+++ b/json-rpc/Tests/JsonRpcTests/JsonRpcTests.swift
@@ -526,7 +526,7 @@ private class BadClient {
         let promise: EventLoopPromise<JSONResponse> = channel.eventLoop.makePromise()
         let encoded = string != "do not encode" ? encode(string, self.framing) : string
         var buffer = channel.allocator.buffer(capacity: encoded.utf8.count)
-        buffer.writeBytes(encoded.utf8)
+        buffer.writeString(encoded)
         let future = channel.writeAndFlush(RequestWrapper(promise: promise, request: buffer))
         future.cascadeFailure(to: promise)
         return future.flatMap {


### PR DESCRIPTION
this contains #1 plus a lot of fixes/cleanup, for example:

- get rid of all `*Unsafe*` calls, @tomerd please file a bug against NIO every time you have to use `*Unsafe*` and you're not interfacing with C
- clean up untrue assumptions like 'readerIndex is always 0' in `buffer.getSlice(at: 9, ...`
- `NewlineCodec` had a needless _O(n)_ implementation of finding `\r\n`, replace this with `LineBasedFrameDecoder` from `swift-nio-extras`
- DRY: don't try to re-implement LineBasedFrameDecoder
- improve pipeline setup